### PR TITLE
Fix iteration bug in orchard multimesh

### DIFF
--- a/godot_projects/nili/nili-simulation/scripts/multi_mesh_instance_3d.gd
+++ b/godot_projects/nili/nili-simulation/scripts/multi_mesh_instance_3d.gd
@@ -54,7 +54,7 @@ func _build_multimesh() -> void:
 	var scale_basis := Basis().scaled(Vector3(radius, height * 0.5, radius)) # CylinderMesh is 1 m tall, centred at origin
 
 	# ── 4. Write per-instance transforms ─────────────────────────
-	for i in verts.size():
+        for i in range(verts.size()):
 		var xform := Transform3D()
 		xform.basis  = scale_basis
 		xform.origin = verts[i]


### PR DESCRIPTION
## Summary
- fix the for-loop used when writing instance transforms

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405eec5ed08331a9f9e11658e541a7